### PR TITLE
dependency on spring-security-messaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,54 +39,53 @@ dependencies {
     compile 'com.amazonaws:aws-java-sdk-s3:1.11.50'
     //compile 'com.amazonaws:aws-java-sdk:1.11.50'
 
-
     /*
      * Immutables library for immutable objects
      */
     apt "org.immutables:value:${immutables_version}"
 
     /*
-     * Servlet API 3.1 
+     * Servlet API 3.1
      * 100% Java Servlet Container and Servlet Configuration
      */
     compile "javax.servlet.jsp:javax.servlet.jsp-api:${javax_servlet_version}"
     compile "javax.servlet:javax.servlet-api:${javax_servlet_api_version}"
-    compile group: 'javax.servlet', name: 'jstl', version:'1.2'
+    compile group: 'javax.servlet', name: 'jstl', version: '1.2'
 
     /*
      * SL4J + LOG4J2
      */
-    compile group: "org.slf4j", name: "slf4j-api", version:"${slf4j_version}"
+    compile group: "org.slf4j", name: "slf4j-api", version: "${slf4j_version}"
 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: "${log4j_version}" 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: "${log4j_version}" 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4j_version}" 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-web', version: "${log4j_version}" 
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: "${log4j_version}"
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: "${log4j_version}"
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4j_version}"
+    compile group: 'org.apache.logging.log4j', name: 'log4j-web', version: "${log4j_version}"
 
     /*
      * CORE SPRING FRAMEWORK DEPENDENCIES
      * Depending injection, asynchronous execution, task scheduling, aspect oriented proxies, and more.
      */
-     compile "org.springframework:spring-core:${project.spring_framework_version}"
-     compile "org.springframework:spring-beans:${project.spring_framework_version}"
-     compile "org.springframework:spring-context:${project.spring_framework_version}"
-     compile "org.springframework:spring-aop:${project.spring_framework_version}"
-     compile "org.springframework:spring-web:${project.spring_framework_version}"
-     compile "org.springframework:spring-webmvc:${project.spring_framework_version}"
-     compile "org.springframework:spring-test:${project.spring_framework_version}"
+    compile "org.springframework:spring-core:${project.spring_framework_version}"
+    compile "org.springframework:spring-beans:${project.spring_framework_version}"
+    compile "org.springframework:spring-context:${project.spring_framework_version}"
+    compile "org.springframework:spring-aop:${project.spring_framework_version}"
+    compile "org.springframework:spring-web:${project.spring_framework_version}"
+    compile "org.springframework:spring-webmvc:${project.spring_framework_version}"
+    compile "org.springframework:spring-test:${project.spring_framework_version}"
 
     /*
      * SPRING SECURITY DEPENDENCIES
      * Solid and battle tested security AuthN/AuthZ framwork
      */
-     compile "org.springframework.security:spring-security-core:${project.spring_security_version}"
-     compile "org.springframework.security:spring-security-web:${project.spring_security_version}"
-     compile "org.springframework.security:spring-security-ldap:${project.spring_security_version}"
-     compile "org.springframework.security:spring-security-config:${project.spring_security_version}"
+    compile "org.springframework.security:spring-security-core:${project.spring_security_version}"
+    compile "org.springframework.security:spring-security-web:${project.spring_security_version}"
+    compile "org.springframework.security:spring-security-ldap:${project.spring_security_version}"
+    compile "org.springframework.security:spring-security-config:${project.spring_security_version}"
 
-     compile ("com.auth0:auth0-spring-security-api:${project.auth0_spring_version}") {
+    compile("com.auth0:auth0-spring-security-api:${project.auth0_spring_version}") {
         exclude group: "org.springframework.boot"
-     }
+    }
 
     /*
      * Metrics
@@ -98,23 +97,23 @@ dependencies {
     compile "com.ryantenney.metrics:metrics-spring:${ryantenney_metrics_version}"
 
     /*
-     * GUAVA 
+     * GUAVA
      * EventBus, FluentIterables, ListenableFutures and more
      */
-     compile "com.google.guava:guava:${guava_version}"
+    compile "com.google.guava:guava:${guava_version}"
 
     /*
      JODA TIME - A better datetime class.
      */
-     compile "joda-time:joda-time:2.9.1"
+    compile "joda-time:joda-time:2.9.1"
 
     /*
      * APACHE COMMONS
      * Logging, StringUtils, RandomStringUtils, IOUtils, and more
      */
-     compile "commons-io:commons-io:2.4"
-     compile "org.apache.commons:commons-lang3:3.4"
-     compile "commons-codec:commons-codec:1.9"
+    compile "commons-io:commons-io:2.4"
+    compile "org.apache.commons:commons-lang3:3.4"
+    compile "commons-codec:commons-codec:1.9"
 
     /*
      * JACKSON SERIALIZATION
@@ -139,115 +138,116 @@ dependencies {
     /*
      * @Inject and @Nullable support
      */
-     compile "javax.inject:javax.inject:1"
-     
+    compile "javax.inject:javax.inject:1"
 
     /*
      * Jersey Spring Integration
      */
-     compile ("org.glassfish.jersey.ext:jersey-spring3:2.23.2") {
+    compile("org.glassfish.jersey.ext:jersey-spring3:2.23.2") {
         exclude module: 'spring-core'
         exclude module: 'spring-beans'
         exclude module: 'spring-web'
-     }
+    }
 
     /*
      * Hibernate Validator
      */
-     compile "org.hibernate:hibernate-validator:${hibernate_version}"
-     compile "javax.el:javax.el-api:2.2.4"
-     compile "org.glassfish.web:javax.el:2.2.4"
-     
+    compile "org.hibernate:hibernate-validator:${hibernate_version}"
+    compile "javax.el:javax.el-api:2.2.4"
+    compile "org.glassfish.web:javax.el:2.2.4"
+
     /*
      * HAZELCAST - DISTRIBUTED DATA GRID
      * Transparent http clustering, distributed java.util collections
      */
-     compile "com.hazelcast:hazelcast:${hazelcast_version}"
-     compile "com.hazelcast:hazelcast-client:${hazelcast_version}"
-     compile "com.hazelcast:hazelcast-wm:${hazelcast_wm_version}"
-     compile "com.hazelcast:hazelcast-spring:${hazelcast_version}"
+    compile "com.hazelcast:hazelcast:${hazelcast_version}"
+    compile "com.hazelcast:hazelcast-client:${hazelcast_version}"
+    compile "com.hazelcast:hazelcast-wm:${hazelcast_wm_version}"
+    compile "com.hazelcast:hazelcast-spring:${hazelcast_version}"
 
 
     /*
      * EMBEDDED JETTY FOR LOCAL TESTING
      * TODO: Add support for Tomcat
      * TODO: Integrate with application plugin for standalone deployment
-     */ 
-     compile "org.ow2.asm:asm:4.1"
-     compile "org.eclipse.jetty.aggregate:jetty-all:${jetty_version}"
-     //TODO: Once GA version of jetty-jsp is released update version.
-     //compile "org.eclipse.jetty:jetty-jsp:9.3.0.M1" 
-     compile "org.eclipse.jetty:jetty-spring:${jetty_version}"
-     compile "org.eclipse.jetty.websocket:websocket-server:${jetty_version}"
-     compile "org.eclipse.jetty.websocket:javax-websocket-server-impl:${jetty_version}"
-     compile "org.eclipse.jetty:jetty-continuation:${jetty_version}"
+     */
+    compile "org.ow2.asm:asm:4.1"
+    compile "org.eclipse.jetty.aggregate:jetty-all:${jetty_version}"
+    //TODO: Once GA version of jetty-jsp is released update version.
+    //compile "org.eclipse.jetty:jetty-jsp:9.3.0.M1"
+    compile "org.eclipse.jetty:jetty-spring:${jetty_version}"
+    compile "org.eclipse.jetty.websocket:websocket-server:${jetty_version}"
+    compile "org.eclipse.jetty.websocket:javax-websocket-server-impl:${jetty_version}"
+    compile "org.eclipse.jetty:jetty-continuation:${jetty_version}"
 
-     compile "io.netty:netty-transport-native-epoll:${netty_epoll_version}:${netty_os_arch}"
+    compile "io.netty:netty-transport-native-epoll:${netty_epoll_version}:${netty_os_arch}"
 
     /*
      * JAVAMAIL
      * Java email client.
      */
-     compile "org.jodd:jodd-mail:3.8.1"
+    compile "org.jodd:jodd-mail:3.8.1"
 
-     /**
-      * Cassandra
-      */
+    /**
+     * Cassandra
+     */
     compile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: "${cassandra_driver_version}"
     compile group: 'com.datastax.cassandra', name: 'cassandra-driver-extras', version: "${cassandra_driver_version}"
     compile group: 'com.datastax.cassandra', name: 'cassandra-driver-mapping', version: "${cassandra_driver_version}"
     compile "org.xerial.snappy:snappy-java:${snappy_version}"
     compile "net.jpountz.lz4:lz4:${lz4_version}"
 
-	/**
-	 * SPARK
-	 */
+    /**
+     * SPARK
+     */
     compile "org.apache.spark:spark-core_2.11:${spark_version}"
     compile "org.apache.spark:spark-sql_2.11:${spark_version}"
-    
+
     /*
      * Jars in lib folder, generally Hyperdex
      */
-     compile fileTree( dir: "lib/", include: "*.jar") 
-     
-     //compile "com.squareup.retrofit:retrofit:${retrofit_version}"
-     //compile "com.squareup.retrofit:retrofit-converters:${retrofit_version}"
+    compile fileTree(dir: "lib/", include: "*.jar")
 
-     compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    //compile "com.squareup.retrofit:retrofit:${retrofit_version}"
+    //compile "com.squareup.retrofit:retrofit-converters:${retrofit_version}"
+
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
 
     /*
      * WEBSOCKET DEPENDENCIES
      */
-      compile "org.springframework:spring-websocket:${project.spring_framework_version}"
-      compile "org.springframework:spring-messaging:${project.spring_framework_version}"
-      compile "org.springframework.integration:spring-integration-websocket:4.3.1.RELEASE"
+    compile "org.springframework:spring-websocket:${project.spring_framework_version}"
+    compile "org.springframework:spring-messaging:${project.spring_framework_version}"
+    compile "org.springframework.integration:spring-integration-websocket:4.3.1.RELEASE"
 
-     /*
+    /*
      * TESTING
      */
-     testCompile 'junit:junit:4.12'
-     testCompile "org.cassandraunit:cassandra-unit:3.1.3.2"
-     /*
-      * TODO: The rest we depend on Loom API via Jar dependency is to avoid circular classpath problems in Eclipse.
-      * Some day we'll either create a separate project or make a rhizome-client library based off retrofit
-      * that loom-api and rhizome server tests can both depend on.
-      */ 
-     
-   if( project.hasProperty('developmentMode') && project.developmentMode ) {
-        logger.quiet(project.name + " using project dependencies.")     
+    testCompile 'junit:junit:4.12'
+    testCompile "org.cassandraunit:cassandra-unit:3.1.3.2"
+
+
+    /*
+     * TODO: The rest we depend on Loom API via Jar dependency is to avoid circular classpath problems in Eclipse.
+     * Some day we'll either create a separate project or make a rhizome-client library based off retrofit
+     * that loom-api and rhizome server tests can both depend on.
+     */
+    if ( project.hasProperty('developmentMode') && project.developmentMode ) {
+        logger.quiet(project.name + " using project dependencies.")
         compile project(":rhizome-client")
     } else {
         logger.quiet(project.name + " using jar dependencies.")
         compile "com.kryptnostic:rhizome-client:${rhizome_client_version}"
     }
-     testCompile 'com.auth0:auth0:0.4.0'
+
+    testCompile 'com.auth0:auth0:0.4.0'
  }
 
 eclipse {
     ext.downloadSources = true
     ext.downloadJavadoc = true
-    ext.sourceCompatibility=JavaVersion.VERSION_1_8
-    ext.targetCompatibility=JavaVersion.VERSION_1_8
+    ext.sourceCompatibility = JavaVersion.VERSION_1_8
+    ext.targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 install {

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     compile "org.springframework.security:spring-security-web:${project.spring_security_version}"
     compile "org.springframework.security:spring-security-ldap:${project.spring_security_version}"
     compile "org.springframework.security:spring-security-config:${project.spring_security_version}"
+    compile "org.springframework.security:spring-security-messaging:${project.spring_security_version}"
 
     compile("com.auth0:auth0-spring-security-api:${project.auth0_spring_version}") {
         exclude group: "org.springframework.boot"


### PR DESCRIPTION
The only actual change is adding a dependency on spring-security-messaging:

```
compile "org.springframework.security:spring-security-messaging:${project.spring_security_version}"
```

Everything else is auto indentation and whitespace fixes by the IDE.